### PR TITLE
feat: add C++ pack

### DIFF
--- a/packs/C++/pipeline.yaml
+++ b/packs/C++/pipeline.yaml
@@ -1,0 +1,27 @@
+extends:
+  file: ../pipeline.yaml
+agent:
+  label: jenkins-cpp
+  container: cpp
+pipelines:
+  pullRequest:
+    build:
+      steps:
+      - sh: cmake3 CMakeLists.txt
+        name: cmake
+      - sh: make
+        name: make
+  release:
+    setVersion:
+      steps:
+      - sh: echo \$(jx-release-version) > VERSION
+        name: next-version
+        comment: so we can retrieve the version in later steps
+      - sh: jx step tag --version \$(cat VERSION)
+        name: tag-version
+    build:
+      steps:
+      - sh: cmake3 CMakeLists.txt
+        name: cmake
+      - sh: make
+        name: make


### PR DESCRIPTION
I'm adding a C++ pack. I copied the template from Dlang and changed the steps.

Some c++ projects require to have a build directory to build and some not. I'm not 100% sure I should add a step to create it. What do you think?

Linked to:
https://github.com/jenkins-x/jenkins-x-platform/pull/4986
https://github.com/jenkins-x-buildpacks/jenkins-x-kubernetes/pull/27