### PR TITLE
Add DOCKER_REGISTRY_ORG environment variable to the Jenkins file

### DIFF
--- a/packs/Jenkinsfile.tmpl
+++ b/packs/Jenkinsfile.tmpl
@@ -4,6 +4,7 @@ pipeline {
     ORG = 'REPLACE_ME_ORG'
     APP_NAME = 'REPLACE_ME_APP_NAME'
     CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+    DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
 {{- .Environment}}
   }
   stages {


### PR DESCRIPTION
This PR sets the DOCKER_REGISTRY_ORG in the Jenkinsfile, which is used in https://github.com/jenkins-x/jx/blob/master/pkg/jx/cmd/preview.go. This should solve this issue 
https://github.com/jenkins-x/jx/issues/3362.