### PR TITLE
Remove custom image from step

### DIFF
--- a/packs/javascript/pipeline.yaml
+++ b/packs/javascript/pipeline.yaml
@@ -9,7 +9,6 @@ pipelines:
       steps:
       - sh: jx step credential -s npm-token -k file -f /builder/home/.npmrc --optional=true
         name: npmrc
-        image: jenkinsxio/jx:2.0.119
       - sh: npm install
         name: npm-install
       - sh: CI=true DISPLAY=:99 npm test
@@ -27,7 +26,6 @@ pipelines:
       steps:
       - sh: jx step credential -s npm-token -k file -f /builder/home/.npmrc --optional=true
         name: npmrc
-        image: jenkinsxio/jx:2.0.119
       - sh: npm install
         name: npm-install
       - sh: CI=true DISPLAY=:99 npm test


### PR DESCRIPTION
Other steps also use `jx` but don't specify the custom image, so it doesn't seem to be required. Specifying a custom image is also causing the Jenkinsfile generation to be broken atm.