### PR TITLE
Perform full release using tagged version

### DIFF
--- a/packs/git/pipeline.yaml
+++ b/packs/git/pipeline.yaml
@@ -9,3 +9,5 @@ pipelines:
       steps:
       - sh: jx step next-version --use-git-tag-only --tag
         name: tag-version
+      - sh: jx step changelog --verbose --version ${VERSION} --rev ${PULL_BASE_SHA}
+        name: release-version


### PR DESCRIPTION
We may not want to release for all repositories using this buildpack, if this is the case I can extend this buildpack and move this extra step into `jenkins-x-versions`.